### PR TITLE
Remove deprecated macos-12 in test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
           - ubuntu-22.04
           - ubuntu-20.04
           - macos-latest
-          # - macos-11  # Some build issues, and it takes 4hr+ to build dependencies. Not worthy.
-          - macos-12
           - macos-13
           - macos-14  # M1 CPU
           - windows-latest


### PR DESCRIPTION
The macOS 12 Actions runner image [has been deprecated](https://github.com/actions/runner-images/issues/10721), the action related with macos-12 would be cancelled automatically.